### PR TITLE
update docker-compose-sanitize.rb script

### DIFF
--- a/docker-compose-sanitize.rb
+++ b/docker-compose-sanitize.rb
@@ -1,18 +1,11 @@
 require 'json'
 require 'yaml'
 
-UNIVERSAL_OPTIONS = ["volumes"]
 sanitize_options = Hash.new {|h,k| h[k]=[]}
 
 CONFIG_FILE = './docker-compose.yml'
 
 config = YAML.load_file(CONFIG_FILE)
-
-config['services'].each do |k, v|
-  UNIVERSAL_OPTIONS.each do |x|
-    sanitize_options[k] << x
-  end
-end
 
 if File.exists?('./service.json')
   service_json = JSON.parse(File.read('./service.json'))

--- a/docker-compose-sanitize.rb
+++ b/docker-compose-sanitize.rb
@@ -9,7 +9,7 @@ CONFIG_FILE = './docker-compose.yml'
 config = YAML.load_file(CONFIG_FILE)
 
 config['services'].each do |k, v|
-  universal_options.each do |x|
+  UNIVERSAL_OPTIONS.each do |x|
     sanitize_options[k] << x
   end
 end

--- a/docker-compose-sanitize.rb
+++ b/docker-compose-sanitize.rb
@@ -15,9 +15,12 @@ config['services'].each do |k, v|
 end
 
 if File.exists?('./service.json')
-  JSON.parse(File.read('./service.json'))["sanitize"].each do |k, v|
-    v.each do |z|
-      sanitize_options[k] << z
+  service_json = JSON.parse(File.read('./service.json'))
+  if service_json.has_key?("sanitize")
+    service_json["sanitize"].each do |k, v|
+      v.each do |z|
+        sanitize_options[k] << z
+      end
     end
   end
 else

--- a/docker-compose-sanitize.rb
+++ b/docker-compose-sanitize.rb
@@ -1,12 +1,13 @@
 require 'json'
 require 'yaml'
 
-universal_options = ["volumes"]
+UNIVERSAL_OPTIONS = ["volumes"]
 sanitize_options = Hash.new {|h,k| h[k]=[]}
 
 CONFIG_FILE = './docker-compose.yml'
 
 config = YAML.load_file(CONFIG_FILE)
+
 config['services'].each do |k, v|
   universal_options.each do |x|
     sanitize_options[k] << x

--- a/docker-compose-sanitize.rb
+++ b/docker-compose-sanitize.rb
@@ -14,7 +14,7 @@ config['services'].each do |k, v|
 end
 
 if File.exists?('./service.json')
-  JSON.parse(File.read('./service.json'))["docker_compose_sanitize"].each do |k, v|
+  JSON.parse(File.read('./service.json'))["sanitize"].each do |k, v|
     v.each do |z|
       sanitize_options[k] << z
     end


### PR DESCRIPTION
![](http://3.bp.blogspot.com/-rKn-9jsHUSU/UmqGqnp_1nI/AAAAAAAADQs/Mav6U6WxXSY/s320/tumblr_m2g4csEOeS1r70nyk.gif)

This script will remove things that are only needed for local development before doing jenkins things on them.  There's a `universal_options` array hardcoded in this script with things we'll always want to strip from services in a docker-compose.yml across the board.  Right now just `volumes` are there.  Additional options to strip for individual projects/services can be passed in via the `docker_compose_sanitize` key in the project's service.json file.  Example to strip the `environment` and `command` options from the app service in a project would look like this in the service.json:

```
{
  "docker_compose_sanitize": {
    "app": ["environment", "command"]
  }
}
```