### PR TITLE
Remove volumes from containers and named volumes if 'strip_volumes' set

### DIFF
--- a/docker-compose-sanitize.rb
+++ b/docker-compose-sanitize.rb
@@ -10,6 +10,16 @@ config = YAML.load_file(CONFIG_FILE)
 
 if File.exists?('./service.json')
   service_json = JSON.parse(File.read('./service.json'))
+
+  if service_json.has_key?('strip_volumes') and service_json['strip_volumes']
+    # remove named volumes
+    config.delete('volumes')
+    # remove volumes from all containers
+    config['services'].each do |service, options|
+      options.delete('volumes')
+    end
+  end
+
   if service_json.has_key?("sanitize")
     service_json["sanitize"].each do |k, v|
       v.each do |z|


### PR DESCRIPTION
Quick and dirty. If `strip_volumes` is set to `true` in `service.json`, the `volumes` option will be removed from all containers in `docker-compose.yml` and all named volumes will be removed as well.

if you're inclined to test:
1. clone
1. copy `docker-compose.yml`, `service.json` to root
1. `ruby docker-compose-sanitize.rb`
1. verify volumes are gone from `docker-compose.yml`